### PR TITLE
Update 10-text-processing-part-2.html

### DIFF
--- a/book/10-text-processing-part-2.html
+++ b/book/10-text-processing-part-2.html
@@ -384,7 +384,7 @@ special characters:</p>
 <pre><code>OS, License, Year
 Chrome OS, Proprietary, 2009
 </code></pre>
-<p>Sometimes we want to the context for a result;
+<p>Sometimes we want the context for a result;
 that is,
 we might want to print lines that surround our matches.
 For example, print the matching line plus the two lines


### PR DESCRIPTION
Hello, this is Miles Hoover from your ICT 418-001 class. 

Looks like there was an extra "to" in this sentence. 

Line 387:
Original -> "Sometimes we want to the context for a result"
Probably meant -> "Sometimes we want the context for a result"

Thanks,
Miles